### PR TITLE
Add Mintable-ERC721&1155 Examples

### DIFF
--- a/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155ChildTunnel.sol
+++ b/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155ChildTunnel.sol
@@ -194,7 +194,7 @@ contract FxMintableERC1155ChildTunnel is FxBaseChildTunnel, Create2, ERC1155Hold
         emit FxWithdrawMintableERC1155(rootToken, childToken, receiver, id, amount);
 
         FxMintableERC1155 rootTokenContract = FxMintableERC1155(childToken);
-        bytes memory metadata = abi.encode(rootTokenContract.uri(id));
+        string memory metadata = rootTokenContract.uri(id);
 
         _sendMessageToRoot(
             abi.encode(WITHDRAW, abi.encode(rootToken, childToken, receiver, id, amount, data, metadata))
@@ -217,23 +217,10 @@ contract FxMintableERC1155ChildTunnel is FxBaseChildTunnel, Create2, ERC1155Hold
         );
 
         FxMintableERC1155 rootTokenContract = FxMintableERC1155(childToken);
-        bytes memory metadata;
-        {
-            uint256 length = ids.length;
-            string[] memory uris = new string[](length);
+        string memory metadata = rootTokenContract.uri(ids[0]);
 
-            for (uint256 i = 0; i < length; ) {
-                uris[i] = rootTokenContract.uri(ids[i]);
-                unchecked {
-                    ++i;
-                }
-            }
-
-            childTokenContract.burnBatch(msg.sender, ids, amounts);
-            emit FxBatchWithdrawMintableERC1155(rootToken, childToken, receiver, ids, amounts);
-
-            metadata = abi.encode(uris);
-        }
+        childTokenContract.burnBatch(msg.sender, ids, amounts);
+        emit FxBatchWithdrawMintableERC1155(rootToken, childToken, receiver, ids, amounts);
 
         _sendMessageToRoot(
             abi.encode(WITHDRAW_BATCH, abi.encode(rootToken, childToken, receiver, ids, amounts, data, metadata))

--- a/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155ChildTunnel.sol
+++ b/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155ChildTunnel.sol
@@ -69,7 +69,7 @@ contract FxMintableERC1155ChildTunnel is FxBaseChildTunnel, Create2, ERC1155Hold
     //
 
     // deploy child token with unique id
-    function deployChildToken(uint256 _uniqueId, string memory _uri) external onlyOwner {
+    function deployChildToken(uint256 _uniqueId, string memory _uri) external {
         // deploy new child token using unique id
         bytes32 childSalt = keccak256(abi.encodePacked(_uniqueId));
         address childToken = createClone(childSalt, childTokenTemplate);
@@ -93,7 +93,7 @@ contract FxMintableERC1155ChildTunnel is FxBaseChildTunnel, Create2, ERC1155Hold
         uint256 _tokenId,
         uint256 _amount,
         bytes calldata _data
-    ) external onlyOwner {
+    ) external {
         FxERC1155 childTokenContract = FxERC1155(_childToken);
         // child token contract will have root token
         address rootToken = childTokenContract.connectedToken();
@@ -227,11 +227,6 @@ contract FxMintableERC1155ChildTunnel is FxBaseChildTunnel, Create2, ERC1155Hold
             "FxMintableERC1155ChildTunnel: NO_MAPPED_TOKEN"
         );
 
-        require(
-            childTokenContract.balanceOf(msg.sender, id) >= amount,
-            "FxMintableERC1155ChildTunnel: INSUFFICIENT_BALANCE"
-        );
-
         childTokenContract.burn(msg.sender, id, amount);
         emit FxWithdrawMintableERC1155(rootToken, childToken, receiver, id, amount);
 
@@ -259,7 +254,6 @@ contract FxMintableERC1155ChildTunnel is FxBaseChildTunnel, Create2, ERC1155Hold
             childToken != address(0x0) && rootToken != address(0x0) && childToken == rootToChildToken[rootToken],
             "FxMintableERC1155ChildTunnel: NO_MAPPED_TOKEN"
         );
-        require(ids.length == amounts.length, "FxMintableERC1155ChildTunnel: LENGTH_MIS_MATCH");
 
         FxERC1155 rootTokenContract = FxERC1155(childToken);
         bytes memory metadata;

--- a/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155ChildTunnel.sol
+++ b/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155ChildTunnel.sol
@@ -69,7 +69,7 @@ contract FxMintableERC1155ChildTunnel is FxBaseChildTunnel, Create2, ERC1155Hold
     //
 
     // deploy child token with unique id
-    function deployChildToken(uint256 _uniqueId, string memory _uri) external {
+    function deployChildToken(uint256 _uniqueId, string calldata _uri) external {
         // deploy new child token using unique id
         address childToken = createClone(keccak256(abi.encodePacked(_uniqueId)), childTokenTemplate); // child salt, childTokenTemplate
 

--- a/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155ChildTunnel.sol
+++ b/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155ChildTunnel.sol
@@ -241,7 +241,7 @@ contract FxMintableERC1155ChildTunnel is FxBaseChildTunnel, Create2, ERC1155Hold
             uint256 length = ids.length;
             string[] memory uris = new string[](length);
 
-            for (uint256 i; i < length; ) {
+            for (uint256 i = 0; i < length; ) {
                 uris[i] = rootTokenContract.uri(ids[i]);
                 unchecked {
                     ++i;

--- a/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155ChildTunnel.sol
+++ b/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155ChildTunnel.sol
@@ -236,11 +236,11 @@ contract FxMintableERC1155ChildTunnel is FxBaseChildTunnel, Create2, ERC1155Hold
         emit FxWithdrawMintableERC1155(rootToken, childToken, receiver, id, amount);
 
         FxERC1155 rootTokenContract = FxERC1155(childToken);
-        bytes memory metaData = abi.encode(rootTokenContract.uri(id));
+        bytes memory metadata = abi.encode(rootTokenContract.uri(id));
 
         bytes memory message = abi.encode(
             WITHDRAW,
-            abi.encode(rootToken, childToken, receiver, id, amount, data, metaData)
+            abi.encode(rootToken, childToken, receiver, id, amount, data, metadata)
         );
         _sendMessageToRoot(message);
     }
@@ -262,7 +262,7 @@ contract FxMintableERC1155ChildTunnel is FxBaseChildTunnel, Create2, ERC1155Hold
         require(ids.length == amounts.length, "FxMintableERC1155ChildTunnel: LENGTH_MIS_MATCH");
 
         FxERC1155 rootTokenContract = FxERC1155(childToken);
-        bytes memory metaData;
+        bytes memory metadata;
         {
             uint256 length = ids.length;
             string[] memory uris = new string[](length);
@@ -277,12 +277,12 @@ contract FxMintableERC1155ChildTunnel is FxBaseChildTunnel, Create2, ERC1155Hold
             childTokenContract.burnBatch(msg.sender, ids, amounts);
             emit FxBatchWithdrawMintableERC1155(rootToken, childToken, receiver, ids, amounts);
 
-            metaData = abi.encode(uris);
+            metadata = abi.encode(uris);
         }
 
         bytes memory message = abi.encode(
             WITHDRAW_BATCH,
-            abi.encode(rootToken, childToken, receiver, ids, amounts, data, metaData)
+            abi.encode(rootToken, childToken, receiver, ids, amounts, data, metadata)
         );
         _sendMessageToRoot(message);
     }

--- a/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155ChildTunnel.sol
+++ b/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155ChildTunnel.sol
@@ -2,11 +2,11 @@
 pragma solidity ^0.8.0;
 
 import {FxERC1155} from "../../tokens/FxERC1155.sol";
-import {ERC1155Holder} from "../../lib/ERC1155Holder.sol";
-import {Create2} from "../../lib/Create2.sol";
 import {FxBaseChildTunnel} from "../../tunnel/FxBaseChildTunnel.sol";
 import {Ownable} from "../../lib/Ownable.sol";
 import {Address} from "../../lib/Address.sol";
+import {ERC1155Holder} from "../../lib/ERC1155Holder.sol";
+import {Create2} from "../../lib/Create2.sol";
 
 contract FxMintableERC1155ChildTunnel is FxBaseChildTunnel, Create2, ERC1155Holder, Ownable {
     bytes32 public constant DEPOSIT = keccak256("DEPOSIT");
@@ -144,26 +144,6 @@ contract FxMintableERC1155ChildTunnel is FxBaseChildTunnel, Create2, ERC1155Hold
         bytes calldata data
     ) public {
         _withdrawBatch(childToken, receiver, ids, amounts, data);
-    }
-
-    function onERC1155Received(
-        address, /* operator */
-        address, /* from */
-        uint256, /* tokenId */
-        uint256, /* amount */
-        bytes memory /* data */
-    ) public pure override returns (bytes4) {
-        return this.onERC1155Received.selector;
-    }
-
-    function onERC1155BatchReceived(
-        address, /* operator */
-        address, /* from */
-        uint256[] memory, /* tokenIds */
-        uint256[] memory, /* amounts */
-        bytes memory /* data */
-    ) public pure override returns (bytes4) {
-        return this.onERC1155BatchReceived.selector;
     }
 
     //

--- a/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155ChildTunnel.sol
+++ b/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155ChildTunnel.sol
@@ -71,12 +71,14 @@ contract FxMintableERC1155ChildTunnel is FxBaseChildTunnel, Create2, ERC1155Hold
     // deploy child token with unique id
     function deployChildToken(uint256 _uniqueId, string memory _uri) external {
         // deploy new child token using unique id
-        bytes32 childSalt = keccak256(abi.encodePacked(_uniqueId));
-        address childToken = createClone(childSalt, childTokenTemplate);
+        address childToken = createClone(keccak256(abi.encodePacked(_uniqueId)), childTokenTemplate); // child salt, childTokenTemplate
 
         // compute root token address before deployment using create2
-        bytes32 rootSalt = keccak256(abi.encodePacked(childToken));
-        address rootToken = computedCreate2Address(rootSalt, rootTokenTemplateCodeHash, fxRootTunnel);
+        address rootToken = computedCreate2Address(
+            keccak256(abi.encodePacked(childToken)), // root salt
+            rootTokenTemplateCodeHash,
+            fxRootTunnel
+        );
 
         // check if mapping is already there
         require(rootToChildToken[rootToken] == address(0x0), "FxMintableERC1155ChildTunnel: ALREADY_MAPPED");
@@ -233,11 +235,9 @@ contract FxMintableERC1155ChildTunnel is FxBaseChildTunnel, Create2, ERC1155Hold
         FxERC1155 rootTokenContract = FxERC1155(childToken);
         bytes memory metadata = abi.encode(rootTokenContract.uri(id));
 
-        bytes memory message = abi.encode(
-            WITHDRAW,
-            abi.encode(rootToken, childToken, receiver, id, amount, data, metadata)
+        _sendMessageToRoot(
+            abi.encode(WITHDRAW, abi.encode(rootToken, childToken, receiver, id, amount, data, metadata))
         );
-        _sendMessageToRoot(message);
     }
 
     function _withdrawBatch(
@@ -274,10 +274,8 @@ contract FxMintableERC1155ChildTunnel is FxBaseChildTunnel, Create2, ERC1155Hold
             metadata = abi.encode(uris);
         }
 
-        bytes memory message = abi.encode(
-            WITHDRAW_BATCH,
-            abi.encode(rootToken, childToken, receiver, ids, amounts, data, metadata)
+        _sendMessageToRoot(
+            abi.encode(WITHDRAW_BATCH, abi.encode(rootToken, childToken, receiver, ids, amounts, data, metadata))
         );
-        _sendMessageToRoot(message);
     }
 }

--- a/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155ChildTunnel.sol
+++ b/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155ChildTunnel.sol
@@ -14,28 +14,28 @@ contract FxMintableERC1155ChildTunnel is FxBaseChildTunnel, Create2, ERC1155Hold
     bytes32 public constant WITHDRAW_BATCH = keccak256("WITHDRAW_BATCH");
 
     event TokenMapped(address indexed rootToken, address indexed childToken);
-    event FxWithdrawERC1155(
+    event FxWithdrawMintableERC1155(
         address indexed rootToken,
         address indexed childToken,
         address indexed userAddress,
         uint256 id,
         uint256 amount
     );
-    event FxDepositERC1155(
+    event FxDepositMintableERC1155(
         address indexed rootToken,
         address indexed depositor,
         address indexed userAddress,
         uint256 id,
         uint256 amount
     );
-    event FxBatchWithdrawERC1155(
+    event FxBatchWithdrawMintableERC1155(
         address indexed rootToken,
         address indexed childToken,
         address indexed userAddress,
         uint256[] ids,
         uint256[] amounts
     );
-    event FxBatchDepositERC1155(
+    event FxBatchDepositMintableERC1155(
         address indexed rootToken,
         address indexed depositor,
         address indexed userAddress,
@@ -188,7 +188,7 @@ contract FxMintableERC1155ChildTunnel is FxBaseChildTunnel, Create2, ERC1155Hold
         FxERC1155 childTokenContract = FxERC1155(childToken);
 
         childTokenContract.mint(to, tokenId, amount, data);
-        emit FxDepositERC1155(rootToken, depositor, to, tokenId, amount);
+        emit FxDepositMintableERC1155(rootToken, depositor, to, tokenId, amount);
     }
 
     function _syncDepositBatch(bytes memory syncData) internal {
@@ -205,7 +205,7 @@ contract FxMintableERC1155ChildTunnel is FxBaseChildTunnel, Create2, ERC1155Hold
         FxERC1155 childTokenContract = FxERC1155(childToken);
 
         childTokenContract.mintBatch(to, tokenIds, amounts, data);
-        emit FxBatchDepositERC1155(rootToken, depositor, to, tokenIds, amounts);
+        emit FxBatchDepositMintableERC1155(rootToken, depositor, to, tokenIds, amounts);
     }
 
     function _withdraw(
@@ -229,7 +229,7 @@ contract FxMintableERC1155ChildTunnel is FxBaseChildTunnel, Create2, ERC1155Hold
         );
 
         childTokenContract.burn(msg.sender, id, amount);
-        emit FxWithdrawERC1155(rootToken, childToken, receiver, id, amount);
+        emit FxWithdrawMintableERC1155(rootToken, childToken, receiver, id, amount);
 
         FxERC1155 rootTokenContract = FxERC1155(childToken);
         bytes memory metaData = abi.encode(rootTokenContract.uri(id));
@@ -271,7 +271,7 @@ contract FxMintableERC1155ChildTunnel is FxBaseChildTunnel, Create2, ERC1155Hold
             }
 
             childTokenContract.burnBatch(msg.sender, ids, amounts);
-            emit FxBatchWithdrawERC1155(rootToken, childToken, receiver, ids, amounts);
+            emit FxBatchWithdrawMintableERC1155(rootToken, childToken, receiver, ids, amounts);
 
             metaData = abi.encode(uris);
         }

--- a/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155ChildTunnel.sol
+++ b/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155ChildTunnel.sol
@@ -55,11 +55,11 @@ contract FxMintableERC1155ChildTunnel is FxBaseChildTunnel, Create2, ERC1155Hold
         address _childTokenTemplate,
         address _rootTokenTemplate
     ) FxBaseChildTunnel(_fxChild) {
-        childTokenTemplate = _childTokenTemplate;
         require(
             Address.isContract(_childTokenTemplate),
             "FxMintableERC1155ChildTunnel: Token template is not contract"
         );
+        childTokenTemplate = _childTokenTemplate;
         // compute root token template code hash
         rootTokenTemplateCodeHash = keccak256(minimalProxyCreationCode(_rootTokenTemplate));
     }

--- a/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155ChildTunnel.sol
+++ b/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155ChildTunnel.sol
@@ -69,7 +69,7 @@ contract FxMintableERC1155ChildTunnel is FxBaseChildTunnel, Create2, ERC1155Hold
     //
 
     // deploy child token with unique id
-    function deployChildToken(uint256 _uniqueId, string calldata _uri) external onlyOwner {
+    function deployChildToken(uint256 _uniqueId, string calldata _uri) external {
         // deploy new child token using unique id
         address childToken = createClone(keccak256(abi.encodePacked(_uniqueId)), childTokenTemplate); // child salt, childTokenTemplate
 

--- a/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155ChildTunnel.sol
+++ b/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155ChildTunnel.sol
@@ -6,6 +6,7 @@ import {ERC1155Holder} from "../../lib/ERC1155Holder.sol";
 import {Create2} from "../../lib/Create2.sol";
 import {FxBaseChildTunnel} from "../../tunnel/FxBaseChildTunnel.sol";
 import {Ownable} from "../../lib/Ownable.sol";
+import {Address} from "../../lib/Address.sol";
 
 contract FxMintableERC1155ChildTunnel is FxBaseChildTunnel, Create2, ERC1155Holder, Ownable {
     bytes32 public constant DEPOSIT = keccak256("DEPOSIT");
@@ -55,7 +56,10 @@ contract FxMintableERC1155ChildTunnel is FxBaseChildTunnel, Create2, ERC1155Hold
         address _rootTokenTemplate
     ) FxBaseChildTunnel(_fxChild) {
         childTokenTemplate = _childTokenTemplate;
-        require(_isContract(_childTokenTemplate), "FxMintableERC1155ChildTunnel: Token template is not contract");
+        require(
+            Address.isContract(_childTokenTemplate),
+            "FxMintableERC1155ChildTunnel: Token template is not contract"
+        );
         // compute root token template code hash
         rootTokenTemplateCodeHash = keccak256(minimalProxyCreationCode(_rootTokenTemplate));
     }
@@ -281,13 +285,5 @@ contract FxMintableERC1155ChildTunnel is FxBaseChildTunnel, Create2, ERC1155Hold
             abi.encode(rootToken, childToken, receiver, ids, amounts, data, metaData)
         );
         _sendMessageToRoot(message);
-    }
-
-    function _isContract(address _addr) private view returns (bool) {
-        uint32 size;
-        assembly {
-            size := extcodesize(_addr)
-        }
-        return (size > 0);
     }
 }

--- a/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155ChildTunnel.sol
+++ b/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155ChildTunnel.sol
@@ -69,7 +69,7 @@ contract FxMintableERC1155ChildTunnel is FxBaseChildTunnel, Create2, ERC1155Hold
     //
 
     // deploy child token with unique id
-    function deployChildToken(uint256 _uniqueId, string calldata _uri) external {
+    function deployChildToken(bytes32 _uniqueId, string calldata _uri) external {
         // deploy new child token using unique id
         address childToken = createClone(keccak256(abi.encodePacked(_uniqueId)), childTokenTemplate); // child salt, childTokenTemplate
 

--- a/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155ChildTunnel.sol
+++ b/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155ChildTunnel.sol
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {FxERC1155} from "../../tokens/FxERC1155.sol";
+import {ERC1155Holder} from "../../lib/ERC1155Holder.sol";
+import {Create2} from "../../lib/Create2.sol";
+import {FxBaseChildTunnel} from "../../tunnel/FxBaseChildTunnel.sol";
+import {Ownable} from "../../lib/Ownable.sol";
+
+contract FxMintableERC1155ChildTunnel is FxBaseChildTunnel, Create2, ERC1155Holder, Ownable {
+    bytes32 public constant DEPOSIT = keccak256("DEPOSIT");
+    bytes32 public constant DEPOSIT_BATCH = keccak256("DEPOSIT_BATCH");
+    bytes32 public constant WITHDRAW = keccak256("WITHDRAW");
+    bytes32 public constant WITHDRAW_BATCH = keccak256("WITHDRAW_BATCH");
+
+    event TokenMapped(address indexed rootToken, address indexed childToken);
+    event FxWithdrawERC1155(
+        address indexed rootToken,
+        address indexed childToken,
+        address indexed userAddress,
+        uint256 id,
+        uint256 amount
+    );
+    event FxDepositERC1155(
+        address indexed rootToken,
+        address indexed depositor,
+        address indexed userAddress,
+        uint256 id,
+        uint256 amount
+    );
+    event FxBatchWithdrawERC1155(
+        address indexed rootToken,
+        address indexed childToken,
+        address indexed userAddress,
+        uint256[] ids,
+        uint256[] amounts
+    );
+    event FxBatchDepositERC1155(
+        address indexed rootToken,
+        address indexed depositor,
+        address indexed userAddress,
+        uint256[] ids,
+        uint256[] amounts
+    );
+    // root to child token
+    mapping(address => address) public rootToChildToken;
+    // child token template
+    address public immutable childTokenTemplate;
+    // root token template codehash
+    bytes32 public immutable rootTokenTemplateCodeHash;
+
+    constructor(
+        address _fxChild,
+        address _childTokenTemplate,
+        address _rootTokenTemplate
+    ) FxBaseChildTunnel(_fxChild) {
+        childTokenTemplate = _childTokenTemplate;
+        require(_isContract(_childTokenTemplate), "FxMintableERC1155ChildTunnel: Token template is not contract");
+        // compute root token template code hash
+        rootTokenTemplateCodeHash = keccak256(minimalProxyCreationCode(_rootTokenTemplate));
+    }
+
+    //
+    // External methods
+    //
+
+    // deploy child token with unique id
+    function deployChildToken(uint256 _uniqueId, string memory _uri) external onlyOwner {
+        // deploy new child token using unique id
+        bytes32 childSalt = keccak256(abi.encodePacked(_uniqueId));
+        address childToken = createClone(childSalt, childTokenTemplate);
+
+        // compute root token address before deployment using create2
+        bytes32 rootSalt = keccak256(abi.encodePacked(childToken));
+        address rootToken = computedCreate2Address(rootSalt, rootTokenTemplateCodeHash, fxRootTunnel);
+
+        // check if mapping is already there
+        require(rootToChildToken[rootToken] == address(0x0), "FxMintableERC1155ChildTunnel: ALREADY_MAPPED");
+        rootToChildToken[rootToken] = childToken;
+        emit TokenMapped(rootToken, childToken);
+
+        // initialize child token with all parameters
+        FxERC1155(childToken).initialize(address(this), rootToken, _uri);
+    }
+
+    // Mint tokens on child chain
+    function mintToken(
+        address _childToken,
+        uint256 _tokenId,
+        uint256 _amount,
+        bytes calldata _data
+    ) external onlyOwner {
+        FxERC1155 childTokenContract = FxERC1155(_childToken);
+        // child token contract will have root token
+        address rootToken = childTokenContract.connectedToken();
+
+        // validate root and child token mapping
+        require(
+            _childToken != address(0x0) && rootToken != address(0x0) && _childToken == rootToChildToken[rootToken],
+            "FxMintableERC721ChildTunnel: NO_MAPPED_TOKEN"
+        );
+        childTokenContract.mint(msg.sender, _tokenId, _amount, _data);
+    }
+
+    function withdraw(
+        address childToken,
+        uint256 id,
+        uint256 amount,
+        bytes calldata data
+    ) public {
+        _withdraw(childToken, msg.sender, id, amount, data);
+    }
+
+    function withdrawTo(
+        address childToken,
+        address receiver,
+        uint256 id,
+        uint256 amount,
+        bytes calldata data
+    ) public {
+        _withdraw(childToken, receiver, id, amount, data);
+    }
+
+    function withdrawBatch(
+        address childToken,
+        uint256[] calldata ids,
+        uint256[] calldata amounts,
+        bytes calldata data
+    ) public {
+        _withdrawBatch(childToken, msg.sender, ids, amounts, data);
+    }
+
+    function withdrawToBatch(
+        address childToken,
+        address receiver,
+        uint256[] calldata ids,
+        uint256[] calldata amounts,
+        bytes calldata data
+    ) public {
+        _withdrawBatch(childToken, receiver, ids, amounts, data);
+    }
+
+    function onERC1155Received(
+        address, /* operator */
+        address, /* from */
+        uint256, /* tokenId */
+        uint256, /* amount */
+        bytes memory /* data */
+    ) public pure override returns (bytes4) {
+        return this.onERC1155Received.selector;
+    }
+
+    function onERC1155BatchReceived(
+        address, /* operator */
+        address, /* from */
+        uint256[] memory, /* tokenIds */
+        uint256[] memory, /* amounts */
+        bytes memory /* data */
+    ) public pure override returns (bytes4) {
+        return this.onERC1155BatchReceived.selector;
+    }
+
+    //
+    // Internal methods
+    //
+
+    function _processMessageFromRoot(
+        uint256, /* stateId */
+        address sender,
+        bytes memory data
+    ) internal override validateSender(sender) {
+        (bytes32 syncType, bytes memory syncData) = abi.decode(data, (bytes32, bytes));
+
+        if (syncType == DEPOSIT) {
+            _syncDeposit(syncData);
+        } else if (syncType == DEPOSIT_BATCH) {
+            _syncDepositBatch(syncData);
+        } else {
+            revert("FxMintableERC1155ChildTunnel: INVALID_SYNC_TYPE");
+        }
+    }
+
+    function _syncDeposit(bytes memory syncData) internal {
+        (address rootToken, address depositor, address to, uint256 tokenId, uint256 amount, bytes memory data) = abi
+            .decode(syncData, (address, address, address, uint256, uint256, bytes));
+
+        address childToken = rootToChildToken[rootToken];
+        FxERC1155 childTokenContract = FxERC1155(childToken);
+
+        childTokenContract.mint(to, tokenId, amount, data);
+        emit FxDepositERC1155(rootToken, depositor, to, tokenId, amount);
+    }
+
+    function _syncDepositBatch(bytes memory syncData) internal {
+        (
+            address rootToken,
+            address depositor,
+            address to,
+            uint256[] memory tokenIds,
+            uint256[] memory amounts,
+            bytes memory data
+        ) = abi.decode(syncData, (address, address, address, uint256[], uint256[], bytes));
+
+        address childToken = rootToChildToken[rootToken];
+        FxERC1155 childTokenContract = FxERC1155(childToken);
+
+        childTokenContract.mintBatch(to, tokenIds, amounts, data);
+        emit FxBatchDepositERC1155(rootToken, depositor, to, tokenIds, amounts);
+    }
+
+    function _withdraw(
+        address childToken,
+        address receiver,
+        uint256 id,
+        uint256 amount,
+        bytes calldata data
+    ) internal {
+        FxERC1155 childTokenContract = FxERC1155(childToken);
+        address rootToken = childTokenContract.connectedToken();
+
+        require(
+            childToken != address(0x0) && rootToken != address(0x0) && childToken == rootToChildToken[rootToken],
+            "FxMintableERC1155ChildTunnel: NO_MAPPED_TOKEN"
+        );
+
+        require(
+            childTokenContract.balanceOf(msg.sender, id) >= amount,
+            "FxMintableERC1155ChildTunnel: INSUFFICIENT_BALANCE"
+        );
+
+        childTokenContract.burn(msg.sender, id, amount);
+        emit FxWithdrawERC1155(rootToken, childToken, receiver, id, amount);
+
+        FxERC1155 rootTokenContract = FxERC1155(childToken);
+        bytes memory metaData = abi.encode(rootTokenContract.uri(id));
+
+        bytes memory message = abi.encode(
+            WITHDRAW,
+            abi.encode(rootToken, childToken, receiver, id, amount, data, metaData)
+        );
+        _sendMessageToRoot(message);
+    }
+
+    function _withdrawBatch(
+        address childToken,
+        address receiver,
+        uint256[] calldata ids,
+        uint256[] calldata amounts,
+        bytes calldata data
+    ) internal {
+        FxERC1155 childTokenContract = FxERC1155(childToken);
+        address rootToken = childTokenContract.connectedToken();
+
+        require(
+            childToken != address(0x0) && rootToken != address(0x0) && childToken == rootToChildToken[rootToken],
+            "FxMintableERC1155ChildTunnel: NO_MAPPED_TOKEN"
+        );
+        require(ids.length == amounts.length, "FxMintableERC1155ChildTunnel: LENGTH_MIS_MATCH");
+
+        FxERC1155 rootTokenContract = FxERC1155(childToken);
+        bytes memory metaData;
+        {
+            uint256 length = ids.length;
+            string[] memory uris = new string[](length);
+
+            for (uint256 i; i < length; ) {
+                uris[i] = rootTokenContract.uri(ids[i]);
+                unchecked {
+                    ++i;
+                }
+            }
+
+            childTokenContract.burnBatch(msg.sender, ids, amounts);
+            emit FxBatchWithdrawERC1155(rootToken, childToken, receiver, ids, amounts);
+
+            metaData = abi.encode(uris);
+        }
+
+        bytes memory message = abi.encode(
+            WITHDRAW_BATCH,
+            abi.encode(rootToken, childToken, receiver, ids, amounts, data, metaData)
+        );
+        _sendMessageToRoot(message);
+    }
+
+    function _isContract(address _addr) private view returns (bool) {
+        uint32 size;
+        assembly {
+            size := extcodesize(_addr)
+        }
+        return (size > 0);
+    }
+}

--- a/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155RootTunnel.sol
+++ b/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155RootTunnel.sol
@@ -64,8 +64,11 @@ contract FxMintableERC1155RootTunnel is FxBaseRootTunnel, Create2, ERC1155Holder
         _sendMessageToChild(message);
 
         // compute child token address before deployment using create2
-        bytes32 salt = keccak256(abi.encodePacked(rootToken));
-        address childToken = computedCreate2Address(salt, childTokenTemplateCodeHash, fxChildTunnel);
+        address childToken = computedCreate2Address(
+            keccak256(abi.encodePacked(rootToken)), // childSalt
+            childTokenTemplateCodeHash,
+            fxChildTunnel
+        );
 
         // add into mapped tokens
         rootToChildTokens[rootToken] = childToken;
@@ -94,8 +97,7 @@ contract FxMintableERC1155RootTunnel is FxBaseRootTunnel, Create2, ERC1155Holder
         );
 
         // DEPOSIT, encode(rootToken, depositor, user, id, amount, extra data)
-        bytes memory message = abi.encode(DEPOSIT, abi.encode(rootToken, msg.sender, user, id, amount, data));
-        _sendMessageToChild(message);
+        _sendMessageToChild(abi.encode(DEPOSIT, abi.encode(rootToken, msg.sender, user, id, amount, data)));
         emit FxDepositMintableERC1155(rootToken, msg.sender, user, id, amount);
     }
 
@@ -121,8 +123,7 @@ contract FxMintableERC1155RootTunnel is FxBaseRootTunnel, Create2, ERC1155Holder
         );
 
         // DEPOSIT_BATCH, encode(rootToken, depositor, user, id, amount, extra data)
-        bytes memory message = abi.encode(DEPOSIT_BATCH, abi.encode(rootToken, msg.sender, user, ids, amounts, data));
-        _sendMessageToChild(message);
+        _sendMessageToChild(abi.encode(DEPOSIT_BATCH, abi.encode(rootToken, msg.sender, user, ids, amounts, data)));
         emit FxDepositBatchMintableERC1155(rootToken, user, ids, amounts);
     }
 

--- a/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155RootTunnel.sol
+++ b/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155RootTunnel.sol
@@ -5,6 +5,7 @@ import {ERC1155} from "../../lib/ERC1155.sol";
 import {ERC1155Holder} from "../../lib/ERC1155Holder.sol";
 import {Create2} from "../../lib/Create2.sol";
 import {FxBaseRootTunnel} from "../../tunnel/FxBaseRootTunnel.sol";
+import {Address} from "../../lib/Address.sol";
 
 contract FxMintableERC1155RootTunnel is FxBaseRootTunnel, Create2, ERC1155Holder {
     bytes32 public constant DEPOSIT = keccak256("DEPOSIT");
@@ -142,6 +143,10 @@ contract FxMintableERC1155RootTunnel is FxBaseRootTunnel, Create2, ERC1155Holder
     function _syncWithdraw(bytes memory syncData) internal {
         (address rootToken, address childToken, address user, uint256 id, uint256 amount, bytes memory data) = abi
             .decode(syncData, (address, address, address, uint256, uint256, bytes));
+        // if root token is not available, create it
+        if (!Address.isContract(rootToken) && rootToChildTokens[rootToken] == address(0x0)) {
+            mapToken(rootToken);
+        }
         require(rootToChildTokens[rootToken] == childToken, "FxMintableERC1155RootTunnel: INVALID_MAPPING_ON_EXIT");
         ERC1155(rootToken).safeTransferFrom(address(this), user, id, amount, data);
         emit FxWithdrawMintableERC1155(rootToken, childToken, user, id, amount);
@@ -156,6 +161,10 @@ contract FxMintableERC1155RootTunnel is FxBaseRootTunnel, Create2, ERC1155Holder
             uint256[] memory amounts,
             bytes memory data
         ) = abi.decode(syncData, (address, address, address, uint256[], uint256[], bytes));
+        // if root token is not available, create it
+        if (!Address.isContract(rootToken) && rootToChildTokens[rootToken] == address(0x0)) {
+            mapToken(rootToken);
+        }
         require(rootToChildTokens[rootToken] == childToken, "FxMintableERC1155RootTunnel: INVALID_MAPPING_ON_EXIT");
         ERC1155(rootToken).safeBatchTransferFrom(address(this), user, ids, amounts, data);
         emit FxWithdrawBatchMintableERC1155(rootToken, childToken, user, ids, amounts);

--- a/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155RootTunnel.sol
+++ b/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155RootTunnel.sol
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {ERC1155} from "../../lib/ERC1155.sol";
+import {ERC1155Holder} from "../../lib/ERC1155Holder.sol";
+import {Create2} from "../../lib/Create2.sol";
+import {FxBaseRootTunnel} from "../../tunnel/FxBaseRootTunnel.sol";
+
+contract FxMintableERC1155RootTunnel is FxBaseRootTunnel, Create2, ERC1155Holder {
+    bytes32 public constant DEPOSIT = keccak256("DEPOSIT");
+    bytes32 public constant DEPOSIT_BATCH = keccak256("DEPOSIT_BATCH");
+    bytes32 public constant WITHDRAW = keccak256("WITHDRAW");
+    bytes32 public constant WITHDRAW_BATCH = keccak256("WITHDRAW_BATCH");
+    bytes32 public constant MAP_TOKEN = keccak256("MAP_TOKEN");
+
+    event TokenMappedERC1155(address indexed rootToken, address indexed childToken);
+    event FxWithdrawERC1155(
+        address indexed rootToken,
+        address indexed childToken,
+        address indexed userAddress,
+        uint256 id,
+        uint256 amount
+    );
+    event FxDepositERC1155(
+        address indexed rootToken,
+        address indexed depositor,
+        address indexed userAddress,
+        uint256 id,
+        uint256 amount
+    );
+    event FxWithdrawBatchERC1155(
+        address indexed rootToken,
+        address indexed childToken,
+        address indexed userAddress,
+        uint256[] ids,
+        uint256[] amounts
+    );
+    event FxDepositBatchERC1155(
+        address indexed rootToken,
+        address indexed userAddress,
+        uint256[] ids,
+        uint256[] amounts
+    );
+
+    mapping(address => address) public rootToChildTokens;
+    bytes32 public immutable childTokenTemplateCodeHash;
+
+    constructor(
+        address _checkpointManager,
+        address _fxRoot,
+        address _fxERC1155Token
+    ) FxBaseRootTunnel(_checkpointManager, _fxRoot) {
+        childTokenTemplateCodeHash = keccak256(minimalProxyCreationCode(_fxERC1155Token));
+    }
+
+    function mapToken(address rootToken) public {
+        require(rootToChildTokens[rootToken] == address(0x0), "FxMintableERC1155RootTunnel: ALREADY_MAPPED");
+
+        ERC1155 rootTokenContract = ERC1155(rootToken);
+        string memory uri = rootTokenContract.uri(0);
+
+        // MAP_TOKEN, encode(rootToken,uri)
+        bytes memory message = abi.encode(MAP_TOKEN, abi.encode(rootToken, uri));
+        _sendMessageToChild(message);
+
+        // compute child token address before deployment using create2
+        bytes32 salt = keccak256(abi.encodePacked(rootToken));
+        address childToken = computedCreate2Address(salt, childTokenTemplateCodeHash, fxChildTunnel);
+
+        // add into mapped tokens
+        rootToChildTokens[rootToken] = childToken;
+        emit TokenMappedERC1155(rootToken, childToken);
+    }
+
+    function deposit(
+        address rootToken,
+        address user,
+        uint256 id,
+        uint256 amount,
+        bytes memory data
+    ) public {
+        // map token if not mapped
+        if (rootToChildTokens[rootToken] == address(0x0)) {
+            mapToken(rootToken);
+        }
+
+        // transfer from depositor to this contract
+        ERC1155(rootToken).safeTransferFrom(
+            msg.sender, // depositor
+            address(this), // manager contract
+            id,
+            amount,
+            data
+        );
+
+        // DEPOSIT, encode(rootToken, depositor, user, id, amount, extra data)
+        bytes memory message = abi.encode(DEPOSIT, abi.encode(rootToken, msg.sender, user, id, amount, data));
+        _sendMessageToChild(message);
+        emit FxDepositERC1155(rootToken, msg.sender, user, id, amount);
+    }
+
+    function depositBatch(
+        address rootToken,
+        address user,
+        uint256[] memory ids,
+        uint256[] memory amounts,
+        bytes memory data
+    ) public {
+        // map token if not mapped
+        if (rootToChildTokens[rootToken] == address(0x0)) {
+            mapToken(rootToken);
+        }
+
+        // transfer from depositor to this contract
+        ERC1155(rootToken).safeBatchTransferFrom(
+            msg.sender, // depositor
+            address(this), // manager contract
+            ids,
+            amounts,
+            data
+        );
+
+        // DEPOSIT_BATCH, encode(rootToken, depositor, user, id, amount, extra data)
+        bytes memory message = abi.encode(DEPOSIT_BATCH, abi.encode(rootToken, msg.sender, user, ids, amounts, data));
+        _sendMessageToChild(message);
+        emit FxDepositBatchERC1155(rootToken, user, ids, amounts);
+    }
+
+    function _processMessageFromChild(bytes memory data) internal override {
+        (bytes32 syncType, bytes memory syncData) = abi.decode(data, (bytes32, bytes));
+
+        if (syncType == WITHDRAW) {
+            _syncWithdraw(syncData);
+        } else if (syncType == WITHDRAW_BATCH) {
+            _syncBatchWithdraw(syncData);
+        } else {
+            revert("FxMintableERC1155RootTunnel: INVALID_SYNC_TYPE");
+        }
+    }
+
+    function _syncWithdraw(bytes memory syncData) internal {
+        (address rootToken, address childToken, address user, uint256 id, uint256 amount, bytes memory data) = abi
+            .decode(syncData, (address, address, address, uint256, uint256, bytes));
+        require(rootToChildTokens[rootToken] == childToken, "FxMintableERC1155RootTunnel: INVALID_MAPPING_ON_EXIT");
+        ERC1155(rootToken).safeTransferFrom(address(this), user, id, amount, data);
+        emit FxWithdrawERC1155(rootToken, childToken, user, id, amount);
+    }
+
+    function _syncBatchWithdraw(bytes memory syncData) internal {
+        (
+            address rootToken,
+            address childToken,
+            address user,
+            uint256[] memory ids,
+            uint256[] memory amounts,
+            bytes memory data
+        ) = abi.decode(syncData, (address, address, address, uint256[], uint256[], bytes));
+        require(rootToChildTokens[rootToken] == childToken, "FxMintableERC1155RootTunnel: INVALID_MAPPING_ON_EXIT");
+        ERC1155(rootToken).safeBatchTransferFrom(address(this), user, ids, amounts, data);
+        emit FxWithdrawBatchERC1155(rootToken, childToken, user, ids, amounts);
+    }
+}

--- a/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155RootTunnel.sol
+++ b/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155RootTunnel.sol
@@ -80,7 +80,7 @@ contract FxMintableERC1155RootTunnel is FxBaseRootTunnel, Create2, ERC1155Holder
         address user,
         uint256 id,
         uint256 amount,
-        bytes memory data
+        bytes calldata data
     ) public {
         // map token if not mapped
         if (rootToChildTokens[rootToken] == address(0x0)) {
@@ -104,9 +104,9 @@ contract FxMintableERC1155RootTunnel is FxBaseRootTunnel, Create2, ERC1155Holder
     function depositBatch(
         address rootToken,
         address user,
-        uint256[] memory ids,
-        uint256[] memory amounts,
-        bytes memory data
+        uint256[] calldata ids,
+        uint256[] calldata amounts,
+        bytes calldata data
     ) public {
         // map token if not mapped
         if (rootToChildTokens[rootToken] == address(0x0)) {

--- a/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155RootTunnel.sol
+++ b/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155RootTunnel.sol
@@ -13,29 +13,29 @@ contract FxMintableERC1155RootTunnel is FxBaseRootTunnel, Create2, ERC1155Holder
     bytes32 public constant WITHDRAW_BATCH = keccak256("WITHDRAW_BATCH");
     bytes32 public constant MAP_TOKEN = keccak256("MAP_TOKEN");
 
-    event TokenMappedERC1155(address indexed rootToken, address indexed childToken);
-    event FxWithdrawERC1155(
+    event TokenMappedMintableERC1155(address indexed rootToken, address indexed childToken);
+    event FxWithdrawMintableERC1155(
         address indexed rootToken,
         address indexed childToken,
         address indexed userAddress,
         uint256 id,
         uint256 amount
     );
-    event FxDepositERC1155(
+    event FxDepositMintableERC1155(
         address indexed rootToken,
         address indexed depositor,
         address indexed userAddress,
         uint256 id,
         uint256 amount
     );
-    event FxWithdrawBatchERC1155(
+    event FxWithdrawBatchMintableERC1155(
         address indexed rootToken,
         address indexed childToken,
         address indexed userAddress,
         uint256[] ids,
         uint256[] amounts
     );
-    event FxDepositBatchERC1155(
+    event FxDepositBatchMintableERC1155(
         address indexed rootToken,
         address indexed userAddress,
         uint256[] ids,
@@ -69,7 +69,7 @@ contract FxMintableERC1155RootTunnel is FxBaseRootTunnel, Create2, ERC1155Holder
 
         // add into mapped tokens
         rootToChildTokens[rootToken] = childToken;
-        emit TokenMappedERC1155(rootToken, childToken);
+        emit TokenMappedMintableERC1155(rootToken, childToken);
     }
 
     function deposit(
@@ -96,7 +96,7 @@ contract FxMintableERC1155RootTunnel is FxBaseRootTunnel, Create2, ERC1155Holder
         // DEPOSIT, encode(rootToken, depositor, user, id, amount, extra data)
         bytes memory message = abi.encode(DEPOSIT, abi.encode(rootToken, msg.sender, user, id, amount, data));
         _sendMessageToChild(message);
-        emit FxDepositERC1155(rootToken, msg.sender, user, id, amount);
+        emit FxDepositMintableERC1155(rootToken, msg.sender, user, id, amount);
     }
 
     function depositBatch(
@@ -123,7 +123,7 @@ contract FxMintableERC1155RootTunnel is FxBaseRootTunnel, Create2, ERC1155Holder
         // DEPOSIT_BATCH, encode(rootToken, depositor, user, id, amount, extra data)
         bytes memory message = abi.encode(DEPOSIT_BATCH, abi.encode(rootToken, msg.sender, user, ids, amounts, data));
         _sendMessageToChild(message);
-        emit FxDepositBatchERC1155(rootToken, user, ids, amounts);
+        emit FxDepositBatchMintableERC1155(rootToken, user, ids, amounts);
     }
 
     function _processMessageFromChild(bytes memory data) internal override {
@@ -143,7 +143,7 @@ contract FxMintableERC1155RootTunnel is FxBaseRootTunnel, Create2, ERC1155Holder
             .decode(syncData, (address, address, address, uint256, uint256, bytes));
         require(rootToChildTokens[rootToken] == childToken, "FxMintableERC1155RootTunnel: INVALID_MAPPING_ON_EXIT");
         ERC1155(rootToken).safeTransferFrom(address(this), user, id, amount, data);
-        emit FxWithdrawERC1155(rootToken, childToken, user, id, amount);
+        emit FxWithdrawMintableERC1155(rootToken, childToken, user, id, amount);
     }
 
     function _syncBatchWithdraw(bytes memory syncData) internal {
@@ -157,6 +157,6 @@ contract FxMintableERC1155RootTunnel is FxBaseRootTunnel, Create2, ERC1155Holder
         ) = abi.decode(syncData, (address, address, address, uint256[], uint256[], bytes));
         require(rootToChildTokens[rootToken] == childToken, "FxMintableERC1155RootTunnel: INVALID_MAPPING_ON_EXIT");
         ERC1155(rootToken).safeBatchTransferFrom(address(this), user, ids, amounts, data);
-        emit FxWithdrawBatchERC1155(rootToken, childToken, user, ids, amounts);
+        emit FxWithdrawBatchMintableERC1155(rootToken, childToken, user, ids, amounts);
     }
 }

--- a/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155RootTunnel.sol
+++ b/contracts/examples/mintable-erc1155-transfer/FxMintableERC1155RootTunnel.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {FxERC1155} from "../../tokens/FxERC1155.sol";
+import {IFxERC1155} from "../../tokens/IFxERC1155.sol";
 import {ERC1155Holder} from "../../lib/ERC1155Holder.sol";
 import {Create2} from "../../lib/Create2.sol";
 import {FxBaseRootTunnel} from "../../tunnel/FxBaseRootTunnel.sol";
@@ -63,7 +63,7 @@ contract FxMintableERC1155RootTunnel is FxBaseRootTunnel, Create2, ERC1155Holder
         require(rootToChildTokens[rootToken] != address(0x0), "FxMintableERC1155RootTunnel: NO_MAPPING_FOUND");
 
         // transfer from depositor to this contract
-        FxERC1155(rootToken).safeTransferFrom(
+        IFxERC1155(rootToken).safeTransferFrom(
             msg.sender, // depositor
             address(this), // manager contract
             id,
@@ -86,7 +86,7 @@ contract FxMintableERC1155RootTunnel is FxBaseRootTunnel, Create2, ERC1155Holder
         require(rootToChildTokens[rootToken] != address(0x0), "FxMintableERC1155RootTunnel: NO_MAPPING_FOUND");
 
         // transfer from depositor to this contract
-        FxERC1155(rootToken).safeBatchTransferFrom(
+        IFxERC1155(rootToken).safeBatchTransferFrom(
             msg.sender, // depositor
             address(this), // manager contract
             ids,
@@ -126,7 +126,7 @@ contract FxMintableERC1155RootTunnel is FxBaseRootTunnel, Create2, ERC1155Holder
             _deployRootToken(rootToken, metadata);
         }
         require(rootToChildTokens[rootToken] == childToken, "FxMintableERC1155RootTunnel: INVALID_MAPPING_ON_EXIT");
-        FxERC1155(rootToken).safeTransferFrom(address(this), user, id, amount, data);
+        IFxERC1155(rootToken).safeTransferFrom(address(this), user, id, amount, data);
         emit FxWithdrawMintableERC1155(rootToken, childToken, user, id, amount);
     }
 
@@ -145,7 +145,7 @@ contract FxMintableERC1155RootTunnel is FxBaseRootTunnel, Create2, ERC1155Holder
             _deployRootToken(rootToken, metadata);
         }
         require(rootToChildTokens[rootToken] == childToken, "FxMintableERC1155RootTunnel: INVALID_MAPPING_ON_EXIT");
-        FxERC1155(rootToken).safeBatchTransferFrom(address(this), user, ids, amounts, data);
+        IFxERC1155(rootToken).safeBatchTransferFrom(address(this), user, ids, amounts, data);
         emit FxWithdrawBatchMintableERC1155(rootToken, childToken, user, ids, amounts);
     }
 
@@ -153,7 +153,7 @@ contract FxMintableERC1155RootTunnel is FxBaseRootTunnel, Create2, ERC1155Holder
         // deploy new root token
         bytes32 salt = keccak256(abi.encodePacked(childToken));
         address rootToken = createClone(salt, rootTokenTemplate);
-        FxERC1155(rootToken).initialize(address(this), childToken, uri);
+        IFxERC1155(rootToken).initialize(address(this), childToken, uri);
 
         // add into mapped tokens
         rootToChildTokens[rootToken] = childToken;

--- a/contracts/examples/mintable-erc721-transfer/FxMintableERC721ChildTunnel.sol
+++ b/contracts/examples/mintable-erc721-transfer/FxMintableERC721ChildTunnel.sol
@@ -54,8 +54,8 @@ contract FxMintableERC721ChildTunnel is FxBaseChildTunnel, Create2, IERC721Recei
     // deploy child token with unique id
     function deployChildToken(
         uint256 _uniqueId,
-        string memory _name,
-        string memory _symbol
+        string calldata _name,
+        string calldata _symbol
     ) external onlyOwner {
         // deploy new child token using unique id
         address childToken = createClone(keccak256(abi.encodePacked(_uniqueId)), childTokenTemplate); // childSalt, childTokenTemplate
@@ -85,7 +85,7 @@ contract FxMintableERC721ChildTunnel is FxBaseChildTunnel, Create2, IERC721Recei
     function mintToken(
         address _childToken,
         uint256 _tokenId,
-        bytes memory _data
+        bytes calldata _data
     ) external onlyOwner {
         FxERC721 childTokenContract = FxERC721(_childToken);
         // child token contract will have root token
@@ -102,7 +102,7 @@ contract FxMintableERC721ChildTunnel is FxBaseChildTunnel, Create2, IERC721Recei
     function withdraw(
         address childToken,
         uint256 tokenId,
-        bytes memory data
+        bytes calldata data
     ) external {
         _withdraw(childToken, msg.sender, tokenId, data);
     }
@@ -111,7 +111,7 @@ contract FxMintableERC721ChildTunnel is FxBaseChildTunnel, Create2, IERC721Recei
         address childToken,
         address receiver,
         uint256 tokenId,
-        bytes memory data
+        bytes calldata data
     ) external {
         _withdraw(childToken, receiver, tokenId, data);
     }
@@ -161,7 +161,7 @@ contract FxMintableERC721ChildTunnel is FxBaseChildTunnel, Create2, IERC721Recei
         address childToken,
         address receiver,
         uint256 tokenId,
-        bytes memory data
+        bytes calldata data
     ) internal {
         FxERC721 childTokenContract = FxERC721(childToken);
         // child token contract will have root token

--- a/contracts/examples/mintable-erc721-transfer/FxMintableERC721ChildTunnel.sol
+++ b/contracts/examples/mintable-erc721-transfer/FxMintableERC721ChildTunnel.sol
@@ -58,12 +58,14 @@ contract FxMintableERC721ChildTunnel is FxBaseChildTunnel, Create2, IERC721Recei
         string memory _symbol
     ) external onlyOwner {
         // deploy new child token using unique id
-        bytes32 childSalt = keccak256(abi.encodePacked(_uniqueId));
-        address childToken = createClone(childSalt, childTokenTemplate);
+        address childToken = createClone(keccak256(abi.encodePacked(_uniqueId)), childTokenTemplate); // childSalt, childTokenTemplate
 
         // compute root token address before deployment using create2
-        bytes32 rootSalt = keccak256(abi.encodePacked(childToken));
-        address rootToken = computedCreate2Address(rootSalt, rootTokenTemplateCodeHash, fxRootTunnel);
+        address rootToken = computedCreate2Address(
+            keccak256(abi.encodePacked(childToken)), // rootSalt
+            rootTokenTemplateCodeHash,
+            fxRootTunnel
+        );
 
         // check if mapping is already there
         require(rootToChildToken[rootToken] == address(0x0), "FxMintableERC721ChildTunnel: ALREADY_MAPPED");

--- a/contracts/examples/mintable-erc721-transfer/FxMintableERC721ChildTunnel.sol
+++ b/contracts/examples/mintable-erc721-transfer/FxMintableERC721ChildTunnel.sol
@@ -53,7 +53,7 @@ contract FxMintableERC721ChildTunnel is FxBaseChildTunnel, Create2, IERC721Recei
 
     // deploy child token with unique id
     function deployChildToken(
-        uint256 _uniqueId,
+        bytes32 _uniqueId,
         string calldata _name,
         string calldata _symbol
     ) external {

--- a/contracts/examples/mintable-erc721-transfer/FxMintableERC721ChildTunnel.sol
+++ b/contracts/examples/mintable-erc721-transfer/FxMintableERC721ChildTunnel.sol
@@ -177,13 +177,12 @@ contract FxMintableERC721ChildTunnel is FxBaseChildTunnel, Create2, IERC721Recei
         childTokenContract.burn(tokenId);
         emit FxWithdrawMintableERC721(rootToken, childToken, receiver, tokenId);
 
-        // ! note: figure out if this metadata is required: if not switch to IFxERC721 or add name and symbol in the interface: https://github.com/ethereum/solidity/issues/13349
         FxERC721 rootTokenContract = FxERC721(childToken);
         string memory name = rootTokenContract.name();
         string memory symbol = rootTokenContract.symbol();
-        bytes memory metaData = abi.encode(name, symbol);
+        bytes memory metadata = abi.encode(name, symbol);
 
         // send message to root regarding token burn
-        _sendMessageToRoot(abi.encode(rootToken, childToken, receiver, tokenId, data, metaData));
+        _sendMessageToRoot(abi.encode(rootToken, childToken, receiver, tokenId, data, metadata));
     }
 }

--- a/contracts/examples/mintable-erc721-transfer/FxMintableERC721ChildTunnel.sol
+++ b/contracts/examples/mintable-erc721-transfer/FxMintableERC721ChildTunnel.sol
@@ -56,7 +56,7 @@ contract FxMintableERC721ChildTunnel is FxBaseChildTunnel, Create2, IERC721Recei
         uint256 _uniqueId,
         string calldata _name,
         string calldata _symbol
-    ) external onlyOwner {
+    ) external {
         // deploy new child token using unique id
         address childToken = createClone(keccak256(abi.encodePacked(_uniqueId)), childTokenTemplate); // childSalt, childTokenTemplate
 

--- a/contracts/examples/mintable-erc721-transfer/FxMintableERC721ChildTunnel.sol
+++ b/contracts/examples/mintable-erc721-transfer/FxMintableERC721ChildTunnel.sol
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {FxBaseChildTunnel} from "../../tunnel/FxBaseChildTunnel.sol";
+import {Create2} from "../../lib/Create2.sol";
+import {FxERC721} from "../../tokens/FxERC721.sol";
+import {IERC721Receiver} from "../../lib/IERC721Receiver.sol";
+import {Ownable} from "../../lib/Ownable.sol";
+
+/**
+ * @title FxMintableERC721ChildTunnel
+ */
+contract FxMintableERC721ChildTunnel is FxBaseChildTunnel, Create2, IERC721Receiver, Ownable {
+    bytes32 public constant DEPOSIT = keccak256("DEPOSIT");
+    // bytes32 public constant MAP_TOKEN = keccak256("MAP_TOKEN");
+    string public constant SUFFIX_NAME = " (FXERC721)";
+    string public constant PREFIX_SYMBOL = "fx";
+
+    event TokenMapped(address indexed rootToken, address indexed childToken);
+    event FxWithdrawERC721(
+        address indexed rootToken,
+        address indexed childToken,
+        address indexed userAddress,
+        uint256 id
+    );
+    event FxDepositERC721(
+        address indexed rootToken,
+        address indexed depositor,
+        address indexed userAddress,
+        uint256 id
+    ); // root to child token
+    mapping(address => address) public rootToChildToken;
+    // child token template
+    address public immutable childTokenTemplate;
+    // root token template codehash
+    bytes32 public immutable rootTokenTemplateCodeHash;
+
+    constructor(
+        address _fxChild,
+        address _childTokenTemplate,
+        address _rootTokenTemplate
+    ) FxBaseChildTunnel(_fxChild) {
+        childTokenTemplate = _childTokenTemplate;
+        require(_isContract(_childTokenTemplate), "FxMintableERC721ChildTunnel: Token template is not contract");
+        // compute root token template code hash
+        rootTokenTemplateCodeHash = keccak256(minimalProxyCreationCode(_rootTokenTemplate));
+    }
+
+    //
+    // External methods
+    //
+
+    // deploy child token with unique id
+    function deployChildToken(
+        uint256 _uniqueId,
+        string memory _name,
+        string memory _symbol
+    ) external onlyOwner {
+        // deploy new child token using unique id
+        bytes32 childSalt = keccak256(abi.encodePacked(_uniqueId));
+        address childToken = createClone(childSalt, childTokenTemplate);
+
+        // compute root token address before deployment using create2
+        bytes32 rootSalt = keccak256(abi.encodePacked(childToken));
+        address rootToken = computedCreate2Address(rootSalt, rootTokenTemplateCodeHash, fxRootTunnel);
+
+        // check if mapping is already there
+        require(rootToChildToken[rootToken] == address(0x0), "FxMintableERC721ChildTunnel: ALREADY_MAPPED");
+        rootToChildToken[rootToken] = childToken;
+        emit TokenMapped(rootToken, childToken);
+
+        // initialize child token with all parameters
+        FxERC721(childToken).initialize(
+            address(this),
+            rootToken,
+            string(abi.encodePacked(_name, SUFFIX_NAME)),
+            string(abi.encodePacked(PREFIX_SYMBOL, _symbol))
+        );
+    }
+
+    // Mint tokens on child chain
+    function mintToken(
+        address _childToken,
+        uint256 _tokenId,
+        bytes memory _data
+    ) external onlyOwner {
+        FxERC721 childTokenContract = FxERC721(_childToken);
+        // child token contract will have root token
+        address rootToken = childTokenContract.connectedToken();
+
+        // validate root and child token mapping
+        require(
+            _childToken != address(0x0) && rootToken != address(0x0) && _childToken == rootToChildToken[rootToken],
+            "FxMintableERC721ChildTunnel: NO_MAPPED_TOKEN"
+        );
+        childTokenContract.mint(msg.sender, _tokenId, _data);
+    }
+
+    function withdraw(
+        address childToken,
+        uint256 tokenId,
+        bytes memory data
+    ) external {
+        _withdraw(childToken, msg.sender, tokenId, data);
+    }
+
+    function withdrawTo(
+        address childToken,
+        address receiver,
+        uint256 tokenId,
+        bytes memory data
+    ) external {
+        _withdraw(childToken, receiver, tokenId, data);
+    }
+
+    function onERC721Received(
+        address, /* operator */
+        address, /* from */
+        uint256, /* tokenId */
+        bytes calldata /* data */
+    ) external pure override returns (bytes4) {
+        return this.onERC721Received.selector;
+    }
+
+    //
+    // Internal methods
+    //
+
+    function _processMessageFromRoot(
+        uint256, /* stateId */
+        address sender,
+        bytes memory data
+    ) internal override validateSender(sender) {
+        // decode incoming data
+        (bytes32 syncType, bytes memory syncData) = abi.decode(data, (bytes32, bytes));
+
+        if (syncType == DEPOSIT) {
+            _syncDeposit(syncData);
+        } else {
+            revert("FxMintableERC721ChildTunnel: INVALID_SYNC_TYPE");
+        }
+    }
+
+    function _syncDeposit(bytes memory syncData) internal {
+        (address rootToken, address depositor, address to, uint256 tokenId, bytes memory depositData) = abi.decode(
+            syncData,
+            (address, address, address, uint256, bytes)
+        );
+        address childToken = rootToChildToken[rootToken];
+
+        // deposit tokens
+        FxERC721 childTokenContract = FxERC721(childToken);
+        childTokenContract.mint(to, tokenId, depositData);
+        emit FxDepositERC721(rootToken, depositor, to, tokenId);
+
+        // ! call `onTokenTranfer` on `to` with limit and ignore error ?
+    }
+
+    function _withdraw(
+        address childToken,
+        address receiver,
+        uint256 tokenId,
+        bytes memory data
+    ) internal {
+        FxERC721 childTokenContract = FxERC721(childToken);
+        // child token contract will have root token
+        address rootToken = childTokenContract.connectedToken();
+
+        // validate root and child token mapping
+        require(
+            childToken != address(0x0) && rootToken != address(0x0) && childToken == rootToChildToken[rootToken],
+            "FxMintableERC721ChildTunnel: NO_MAPPED_TOKEN"
+        );
+
+        require(msg.sender == childTokenContract.ownerOf(tokenId));
+
+        // withdraw tokens
+        childTokenContract.burn(tokenId);
+        emit FxWithdrawERC721(rootToken, childToken, receiver, tokenId);
+
+        // ! note: figure out if this metadata is required: if not switch to IFxERC721 or add name and symbol in the interface: https://github.com/ethereum/solidity/issues/13349
+        FxERC721 rootTokenContract = FxERC721(childToken);
+        string memory name = rootTokenContract.name();
+        string memory symbol = rootTokenContract.symbol();
+        bytes memory metaData = abi.encode(name, symbol);
+
+        // send message to root regarding token burn
+        _sendMessageToRoot(abi.encode(rootToken, childToken, receiver, tokenId, data, metaData));
+    }
+
+    // check if address is contract
+    function _isContract(address _addr) private view returns (bool) {
+        uint32 size;
+        assembly {
+            size := extcodesize(_addr)
+        }
+        return (size > 0);
+    }
+}

--- a/contracts/examples/mintable-erc721-transfer/FxMintableERC721ChildTunnel.sol
+++ b/contracts/examples/mintable-erc721-transfer/FxMintableERC721ChildTunnel.sol
@@ -17,13 +17,13 @@ contract FxMintableERC721ChildTunnel is FxBaseChildTunnel, Create2, IERC721Recei
     string public constant PREFIX_SYMBOL = "fx";
 
     event TokenMapped(address indexed rootToken, address indexed childToken);
-    event FxWithdrawERC721(
+    event FxWithdrawMintableERC721(
         address indexed rootToken,
         address indexed childToken,
         address indexed userAddress,
         uint256 id
     );
-    event FxDepositERC721(
+    event FxDepositMintableERC721(
         address indexed rootToken,
         address indexed depositor,
         address indexed userAddress,
@@ -151,9 +151,7 @@ contract FxMintableERC721ChildTunnel is FxBaseChildTunnel, Create2, IERC721Recei
         // deposit tokens
         FxERC721 childTokenContract = FxERC721(childToken);
         childTokenContract.mint(to, tokenId, depositData);
-        emit FxDepositERC721(rootToken, depositor, to, tokenId);
-
-        // ! call `onTokenTranfer` on `to` with limit and ignore error ?
+        emit FxDepositMintableERC721(rootToken, depositor, to, tokenId);
     }
 
     function _withdraw(
@@ -176,7 +174,7 @@ contract FxMintableERC721ChildTunnel is FxBaseChildTunnel, Create2, IERC721Recei
 
         // withdraw tokens
         childTokenContract.burn(tokenId);
-        emit FxWithdrawERC721(rootToken, childToken, receiver, tokenId);
+        emit FxWithdrawMintableERC721(rootToken, childToken, receiver, tokenId);
 
         // ! note: figure out if this metadata is required: if not switch to IFxERC721 or add name and symbol in the interface: https://github.com/ethereum/solidity/issues/13349
         FxERC721 rootTokenContract = FxERC721(childToken);

--- a/contracts/examples/mintable-erc721-transfer/FxMintableERC721ChildTunnel.sol
+++ b/contracts/examples/mintable-erc721-transfer/FxMintableERC721ChildTunnel.sol
@@ -41,8 +41,8 @@ contract FxMintableERC721ChildTunnel is FxBaseChildTunnel, Create2, IERC721Recei
         address _childTokenTemplate,
         address _rootTokenTemplate
     ) FxBaseChildTunnel(_fxChild) {
-        childTokenTemplate = _childTokenTemplate;
         require(Address.isContract(_childTokenTemplate), "FxMintableERC721ChildTunnel: Token template is not contract");
+        childTokenTemplate = _childTokenTemplate;
         // compute root token template code hash
         rootTokenTemplateCodeHash = keccak256(minimalProxyCreationCode(_rootTokenTemplate));
     }

--- a/contracts/examples/mintable-erc721-transfer/FxMintableERC721ChildTunnel.sol
+++ b/contracts/examples/mintable-erc721-transfer/FxMintableERC721ChildTunnel.sol
@@ -6,6 +6,7 @@ import {Create2} from "../../lib/Create2.sol";
 import {FxERC721} from "../../tokens/FxERC721.sol";
 import {IERC721Receiver} from "../../lib/IERC721Receiver.sol";
 import {Ownable} from "../../lib/Ownable.sol";
+import {Address} from "../../lib/Address.sol";
 
 /**
  * @title FxMintableERC721ChildTunnel
@@ -41,7 +42,7 @@ contract FxMintableERC721ChildTunnel is FxBaseChildTunnel, Create2, IERC721Recei
         address _rootTokenTemplate
     ) FxBaseChildTunnel(_fxChild) {
         childTokenTemplate = _childTokenTemplate;
-        require(_isContract(_childTokenTemplate), "FxMintableERC721ChildTunnel: Token template is not contract");
+        require(Address.isContract(_childTokenTemplate), "FxMintableERC721ChildTunnel: Token template is not contract");
         // compute root token template code hash
         rootTokenTemplateCodeHash = keccak256(minimalProxyCreationCode(_rootTokenTemplate));
     }
@@ -184,14 +185,5 @@ contract FxMintableERC721ChildTunnel is FxBaseChildTunnel, Create2, IERC721Recei
 
         // send message to root regarding token burn
         _sendMessageToRoot(abi.encode(rootToken, childToken, receiver, tokenId, data, metaData));
-    }
-
-    // check if address is contract
-    function _isContract(address _addr) private view returns (bool) {
-        uint32 size;
-        assembly {
-            size := extcodesize(_addr)
-        }
-        return (size > 0);
     }
 }

--- a/contracts/examples/mintable-erc721-transfer/FxMintableERC721RootTunnel.sol
+++ b/contracts/examples/mintable-erc721-transfer/FxMintableERC721RootTunnel.sol
@@ -46,7 +46,7 @@ contract FxMintableERC721RootTunnel is FxBaseRootTunnel, Create2, IERC721Receive
         address rootToken,
         address user,
         uint256 tokenId,
-        bytes memory data
+        bytes calldata data
     ) external {
         require(rootToChildTokens[rootToken] != address(0x0), "FxMintableERC721RootTunnel: NO_MAPPING_FOUND");
 

--- a/contracts/examples/mintable-erc721-transfer/FxMintableERC721RootTunnel.sol
+++ b/contracts/examples/mintable-erc721-transfer/FxMintableERC721RootTunnel.sol
@@ -85,11 +85,11 @@ contract FxMintableERC721RootTunnel is FxBaseRootTunnel, Create2, IERC721Receive
             address to,
             uint256 tokenId,
             bytes memory syncData,
-            bytes memory metaData
+            bytes memory metadata
         ) = abi.decode(data, (address, address, address, uint256, bytes, bytes));
         // if root token is not available, create it
         if (!Address.isContract(rootToken) && rootToChildTokens[rootToken] == address(0x0)) {
-            (string memory name, string memory symbol) = abi.decode(metaData, (string, string));
+            (string memory name, string memory symbol) = abi.decode(metadata, (string, string));
             address _createdToken = _deployRootToken(childToken, name, symbol);
             require(_createdToken == rootToken, "FxMintableERC721RootTunnel: ROOT_TOKEN_CREATION_MISMATCH");
         }

--- a/contracts/examples/mintable-erc721-transfer/FxMintableERC721RootTunnel.sol
+++ b/contracts/examples/mintable-erc721-transfer/FxMintableERC721RootTunnel.sol
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {FxERC721} from "../../tokens/FxERC721.sol";
+import {Create2} from "../../lib/Create2.sol";
+import {FxBaseRootTunnel} from "../../tunnel/FxBaseRootTunnel.sol";
+import {IERC721Receiver} from "../../lib/IERC721Receiver.sol";
+
+/**
+ * @title FxMintableERC721RootTunnel
+ */
+contract FxMintableERC721RootTunnel is FxBaseRootTunnel, Create2, IERC721Receiver {
+    bytes32 public constant DEPOSIT = keccak256("DEPOSIT");
+
+    event TokenMapped(address indexed rootToken, address indexed childToken);
+    event FxWithdrawERC721(
+        address indexed rootToken,
+        address indexed childToken,
+        address indexed userAddress,
+        uint256 id
+    );
+    event FxDepositERC721(
+        address indexed rootToken,
+        address indexed depositor,
+        address indexed userAddress,
+        uint256 id
+    );
+
+    mapping(address => address) public rootToChildTokens;
+    address public immutable rootTokenTemplate;
+
+    constructor(
+        address _checkpointManager,
+        address _fxRoot,
+        address _rootTokenTemplate
+    ) FxBaseRootTunnel(_checkpointManager, _fxRoot) {
+        rootTokenTemplate = _rootTokenTemplate;
+    }
+
+    //
+    // External methods
+    //
+
+    function deposit(
+        address rootToken,
+        address user,
+        uint256 tokenId,
+        bytes memory data
+    ) external {
+        require(rootToChildTokens[rootToken] != address(0x0), "FxMintableERC721RootTunnel: NO_MAPPING_FOUND");
+
+        // transfer from depositor to this contract
+        FxERC721(rootToken).safeTransferFrom(
+            msg.sender, // depositor
+            address(this), // manager contract
+            tokenId,
+            data
+        );
+
+        // DEPOSIT, encode(rootToken, depositor, user, tokenId, extra data)
+        bytes memory message = abi.encode(DEPOSIT, abi.encode(rootToken, msg.sender, user, tokenId, data));
+        _sendMessageToChild(message);
+        emit FxDepositERC721(rootToken, msg.sender, user, tokenId);
+    }
+
+    function onERC721Received(
+        address, /* operator */
+        address, /* from */
+        uint256, /* tokenId */
+        bytes calldata /* data */
+    ) external pure override returns (bytes4) {
+        return this.onERC721Received.selector;
+    }
+
+    //
+    // Internal methods
+    //
+
+    // exit processor
+    function _processMessageFromChild(bytes memory data) internal override {
+        (
+            address rootToken,
+            address childToken,
+            address to,
+            uint256 tokenId,
+            bytes memory syncData,
+            bytes memory metaData
+        ) = abi.decode(data, (address, address, address, uint256, bytes, bytes));
+        // if root token is not available, create it
+        if (!_isContract(rootToken) && rootToChildTokens[rootToken] == address(0x0)) {
+            (string memory name, string memory symbol) = abi.decode(metaData, (string, string));
+            address _createdToken = _deployRootToken(childToken, name, symbol);
+            require(_createdToken == rootToken, "FxMintableERC721RootTunnel: ROOT_TOKEN_CREATION_MISMATCH");
+        }
+
+        // validate mapping for root to child
+        require(rootToChildTokens[rootToken] == childToken, "FxMintableERC721RootTunnel: INVALID_MAPPING_ON_EXIT");
+
+        // check if current token has been minted on root chain
+        // ! for 1155: check amount here
+        FxERC721 nft = FxERC721(rootToken);
+        address currentOwner = nft.ownerOf(tokenId);
+        if (currentOwner == address(0)) {
+            nft.mint(address(this), tokenId, "");
+        }
+
+        // transfer from tokens to
+        FxERC721(rootToken).safeTransferFrom(address(this), to, tokenId, syncData);
+        emit FxWithdrawERC721(rootToken, childToken, to, tokenId);
+    }
+
+    function _deployRootToken(
+        address childToken,
+        string memory name,
+        string memory symbol
+    ) internal returns (address) {
+        // deploy new root token
+        bytes32 salt = keccak256(abi.encodePacked(childToken));
+        address rootToken = createClone(salt, rootTokenTemplate);
+        FxERC721(rootToken).initialize(address(this), childToken, name, symbol);
+
+        // add into mapped tokens
+        rootToChildTokens[rootToken] = childToken;
+        emit TokenMapped(rootToken, childToken);
+
+        return rootToken;
+    }
+
+    // check if address is contract
+    function _isContract(address _addr) private view returns (bool) {
+        uint32 size;
+        assembly {
+            size := extcodesize(_addr)
+        }
+        return (size > 0);
+    }
+}

--- a/contracts/examples/mintable-erc721-transfer/FxMintableERC721RootTunnel.sol
+++ b/contracts/examples/mintable-erc721-transfer/FxMintableERC721RootTunnel.sol
@@ -5,6 +5,7 @@ import {FxERC721} from "../../tokens/FxERC721.sol";
 import {Create2} from "../../lib/Create2.sol";
 import {FxBaseRootTunnel} from "../../tunnel/FxBaseRootTunnel.sol";
 import {IERC721Receiver} from "../../lib/IERC721Receiver.sol";
+import {Address} from "../../lib/Address.sol";
 
 /**
  * @title FxMintableERC721RootTunnel
@@ -87,7 +88,7 @@ contract FxMintableERC721RootTunnel is FxBaseRootTunnel, Create2, IERC721Receive
             bytes memory metaData
         ) = abi.decode(data, (address, address, address, uint256, bytes, bytes));
         // if root token is not available, create it
-        if (!_isContract(rootToken) && rootToChildTokens[rootToken] == address(0x0)) {
+        if (!Address.isContract(rootToken) && rootToChildTokens[rootToken] == address(0x0)) {
             (string memory name, string memory symbol) = abi.decode(metaData, (string, string));
             address _createdToken = _deployRootToken(childToken, name, symbol);
             require(_createdToken == rootToken, "FxMintableERC721RootTunnel: ROOT_TOKEN_CREATION_MISMATCH");
@@ -124,14 +125,5 @@ contract FxMintableERC721RootTunnel is FxBaseRootTunnel, Create2, IERC721Receive
         emit TokenMapped(rootToken, childToken);
 
         return rootToken;
-    }
-
-    // check if address is contract
-    function _isContract(address _addr) private view returns (bool) {
-        uint32 size;
-        assembly {
-            size := extcodesize(_addr)
-        }
-        return (size > 0);
     }
 }

--- a/contracts/examples/mintable-erc721-transfer/FxMintableERC721RootTunnel.sol
+++ b/contracts/examples/mintable-erc721-transfer/FxMintableERC721RootTunnel.sol
@@ -13,13 +13,13 @@ contract FxMintableERC721RootTunnel is FxBaseRootTunnel, Create2, IERC721Receive
     bytes32 public constant DEPOSIT = keccak256("DEPOSIT");
 
     event TokenMapped(address indexed rootToken, address indexed childToken);
-    event FxWithdrawERC721(
+    event FxWithdrawMintableERC721(
         address indexed rootToken,
         address indexed childToken,
         address indexed userAddress,
         uint256 id
     );
-    event FxDepositERC721(
+    event FxDepositMintableERC721(
         address indexed rootToken,
         address indexed depositor,
         address indexed userAddress,
@@ -60,7 +60,7 @@ contract FxMintableERC721RootTunnel is FxBaseRootTunnel, Create2, IERC721Receive
         // DEPOSIT, encode(rootToken, depositor, user, tokenId, extra data)
         bytes memory message = abi.encode(DEPOSIT, abi.encode(rootToken, msg.sender, user, tokenId, data));
         _sendMessageToChild(message);
-        emit FxDepositERC721(rootToken, msg.sender, user, tokenId);
+        emit FxDepositMintableERC721(rootToken, msg.sender, user, tokenId);
     }
 
     function onERC721Received(
@@ -106,7 +106,7 @@ contract FxMintableERC721RootTunnel is FxBaseRootTunnel, Create2, IERC721Receive
 
         // transfer from tokens to
         FxERC721(rootToken).safeTransferFrom(address(this), to, tokenId, syncData);
-        emit FxWithdrawERC721(rootToken, childToken, to, tokenId);
+        emit FxWithdrawMintableERC721(rootToken, childToken, to, tokenId);
     }
 
     function _deployRootToken(

--- a/contracts/examples/mintable-erc721-transfer/FxMintableERC721RootTunnel.sol
+++ b/contracts/examples/mintable-erc721-transfer/FxMintableERC721RootTunnel.sol
@@ -59,8 +59,7 @@ contract FxMintableERC721RootTunnel is FxBaseRootTunnel, Create2, IERC721Receive
         );
 
         // DEPOSIT, encode(rootToken, depositor, user, tokenId, extra data)
-        bytes memory message = abi.encode(DEPOSIT, abi.encode(rootToken, msg.sender, user, tokenId, data));
-        _sendMessageToChild(message);
+        _sendMessageToChild(abi.encode(DEPOSIT, abi.encode(rootToken, msg.sender, user, tokenId, data)));
         emit FxDepositMintableERC721(rootToken, msg.sender, user, tokenId);
     }
 
@@ -98,7 +97,6 @@ contract FxMintableERC721RootTunnel is FxBaseRootTunnel, Create2, IERC721Receive
         require(rootToChildTokens[rootToken] == childToken, "FxMintableERC721RootTunnel: INVALID_MAPPING_ON_EXIT");
 
         // check if current token has been minted on root chain
-        // ! for 1155: check amount here
         FxERC721 nft = FxERC721(rootToken);
         address currentOwner = nft.ownerOf(tokenId);
         if (currentOwner == address(0)) {

--- a/contracts/examples/mintable-erc721-transfer/FxMintableERC721RootTunnel.sol
+++ b/contracts/examples/mintable-erc721-transfer/FxMintableERC721RootTunnel.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {FxERC721} from "../../tokens/FxERC721.sol";
+import {IFxERC721} from "../../tokens/IFxERC721.sol";
 import {Create2} from "../../lib/Create2.sol";
 import {FxBaseRootTunnel} from "../../tunnel/FxBaseRootTunnel.sol";
 import {IERC721Receiver} from "../../lib/IERC721Receiver.sol";
@@ -51,7 +51,7 @@ contract FxMintableERC721RootTunnel is FxBaseRootTunnel, Create2, IERC721Receive
         require(rootToChildTokens[rootToken] != address(0x0), "FxMintableERC721RootTunnel: NO_MAPPING_FOUND");
 
         // transfer from depositor to this contract
-        FxERC721(rootToken).safeTransferFrom(
+        IFxERC721(rootToken).safeTransferFrom(
             msg.sender, // depositor
             address(this), // manager contract
             tokenId,
@@ -97,14 +97,14 @@ contract FxMintableERC721RootTunnel is FxBaseRootTunnel, Create2, IERC721Receive
         require(rootToChildTokens[rootToken] == childToken, "FxMintableERC721RootTunnel: INVALID_MAPPING_ON_EXIT");
 
         // check if current token has been minted on root chain
-        FxERC721 nft = FxERC721(rootToken);
+        IFxERC721 nft = IFxERC721(rootToken);
         address currentOwner = nft.ownerOf(tokenId);
         if (currentOwner == address(0)) {
             nft.mint(address(this), tokenId, "");
         }
 
         // transfer from tokens to
-        FxERC721(rootToken).safeTransferFrom(address(this), to, tokenId, syncData);
+        IFxERC721(rootToken).safeTransferFrom(address(this), to, tokenId, syncData);
         emit FxWithdrawMintableERC721(rootToken, childToken, to, tokenId);
     }
 
@@ -116,7 +116,7 @@ contract FxMintableERC721RootTunnel is FxBaseRootTunnel, Create2, IERC721Receive
         // deploy new root token
         bytes32 salt = keccak256(abi.encodePacked(childToken));
         address rootToken = createClone(salt, rootTokenTemplate);
-        FxERC721(rootToken).initialize(address(this), childToken, name, symbol);
+        IFxERC721(rootToken).initialize(address(this), childToken, name, symbol);
 
         // add into mapped tokens
         rootToChildTokens[rootToken] = childToken;

--- a/contracts/examples/mintable-erc721-transfer/FxMintableERC721RootTunnel.sol
+++ b/contracts/examples/mintable-erc721-transfer/FxMintableERC721RootTunnel.sol
@@ -13,7 +13,7 @@ import {Address} from "../../lib/Address.sol";
 contract FxMintableERC721RootTunnel is FxBaseRootTunnel, Create2, IERC721Receiver {
     bytes32 public constant DEPOSIT = keccak256("DEPOSIT");
 
-    event TokenMapped(address indexed rootToken, address indexed childToken);
+    event TokenMappedMintableERC721(address indexed rootToken, address indexed childToken);
     event FxWithdrawMintableERC721(
         address indexed rootToken,
         address indexed childToken,
@@ -120,7 +120,7 @@ contract FxMintableERC721RootTunnel is FxBaseRootTunnel, Create2, IERC721Receive
 
         // add into mapped tokens
         rootToChildTokens[rootToken] = childToken;
-        emit TokenMapped(rootToken, childToken);
+        emit TokenMappedMintableERC721(rootToken, childToken);
 
         return rootToken;
     }

--- a/contracts/tokens/FxMintableERC1155.sol
+++ b/contracts/tokens/FxMintableERC1155.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+import {ERC1155} from "../lib/ERC1155.sol";
+import {IFxMintableERC1155} from "./IFxMintableERC1155.sol";
+
+contract FxMintableERC1155 is ERC1155, IFxMintableERC1155 {
+    address internal _fxManager;
+    address internal _connectedToken;
+
+    address public minter;
+
+    modifier onlyMinterOrFxManager() {
+        require(msg.sender == minter || msg.sender == _fxManager, "Invalid sender");
+        _;
+    }
+
+    function initialize(
+        address fxManager_,
+        address connectedToken_,
+        string calldata uri_,
+        address minter_
+    ) public override {
+        require(_fxManager == address(0x0) && _connectedToken == address(0x0), "Token is already initialized");
+        _fxManager = fxManager_;
+        _connectedToken = connectedToken_;
+
+        setupMetaData(uri_);
+        minter = minter_;
+    }
+
+    function fxManager() public view override returns (address) {
+        return _fxManager;
+    }
+
+    function connectedToken() public view override returns (address) {
+        return _connectedToken;
+    }
+
+    function setupMetaData(string memory _uri) public {
+        require(msg.sender == _fxManager, "Invalid sender");
+        _setupMetaData(_uri);
+    }
+
+    function updateMinter(address who) external onlyMinterOrFxManager {
+        minter = who;
+    }
+
+    function mintToken(
+        address user,
+        uint256 id,
+        uint256 amount,
+        bytes calldata data
+    ) external override onlyMinterOrFxManager {
+        _mint(user, id, amount, data);
+    }
+
+    function mintTokenBatch(
+        address user,
+        uint256[] calldata ids,
+        uint256[] calldata amounts,
+        bytes calldata data
+    ) external override onlyMinterOrFxManager {
+        _mintBatch(user, ids, amounts, data);
+    }
+
+    function burn(
+        address user,
+        uint256 id,
+        uint256 amount
+    ) public override {
+        require(msg.sender == _fxManager, "Invalid sender");
+        _burn(user, id, amount);
+    }
+
+    function burnBatch(
+        address user,
+        uint256[] calldata ids,
+        uint256[] calldata amounts
+    ) public override {
+        require(msg.sender == _fxManager, "Invalid sender");
+        _burnBatch(user, ids, amounts);
+    }
+}

--- a/contracts/tokens/FxMintableERC721.sol
+++ b/contracts/tokens/FxMintableERC721.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {ERC721} from "../lib/ERC721.sol";
+import {IFxMintableERC721} from "./IFxMintableERC721.sol";
+
+/**
+ * @title FxERC20 represents fx erc20
+ */
+contract FxMintableERC721 is IFxMintableERC721, ERC721 {
+    address internal _fxManager;
+    address internal _connectedToken;
+
+    address public minter;
+
+    modifier onlyMinterOrFxManager() {
+        require(msg.sender == minter || msg.sender == _fxManager, "Invalid sender");
+        _;
+    }
+
+    function initialize(
+        address fxManager_,
+        address connectedToken_,
+        string calldata name_,
+        string calldata symbol_,
+        address minter_
+    ) public override {
+        require(_fxManager == address(0x0) && _connectedToken == address(0x0), "Token is already initialized");
+        _fxManager = fxManager_;
+        _connectedToken = connectedToken_;
+
+        // setup meta data
+        setupMetaData(name_, symbol_);
+        minter = minter_;
+    }
+
+    // fxManager returns fx manager
+    function fxManager() public view override returns (address) {
+        return _fxManager;
+    }
+
+    // connectedToken returns root token
+    function connectedToken() public view override returns (address) {
+        return _connectedToken;
+    }
+
+    // setup name, symbol and decimals
+    function setupMetaData(string memory _name, string memory _symbol) public {
+        require(msg.sender == _fxManager, "Invalid sender");
+        _setupMetaData(_name, _symbol);
+    }
+
+    function updateMinter(address who) external onlyMinterOrFxManager {
+        minter = who;
+    }
+
+    function mintToken(
+        address user,
+        uint256 tokenId,
+        bytes calldata _data
+    ) external override onlyMinterOrFxManager {
+        _safeMint(user, tokenId, _data);
+    }
+
+    function burn(uint256 tokenId) public override {
+        require(msg.sender == _fxManager, "Invalid sender");
+        _burn(tokenId);
+    }
+}

--- a/contracts/tokens/IFxMintableERC1155.sol
+++ b/contracts/tokens/IFxMintableERC1155.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {IERC1155} from "../lib/IERC1155.sol";
+
+interface IFxMintableERC1155 is IERC1155 {
+    function fxManager() external returns (address);
+
+    function initialize(
+        address fxManager,
+        address connectedToken,
+        string calldata uri,
+        address minter
+    ) external;
+
+    function connectedToken() external returns (address);
+
+    function mintToken(
+        address user,
+        uint256 id,
+        uint256 amount,
+        bytes calldata data
+    ) external;
+
+    function mintTokenBatch(
+        address user,
+        uint256[] calldata ids,
+        uint256[] calldata amounts,
+        bytes calldata data
+    ) external;
+
+    function burn(
+        address user,
+        uint256 id,
+        uint256 amount
+    ) external;
+
+    function burnBatch(
+        address user,
+        uint256[] calldata ids,
+        uint256[] calldata amounts
+    ) external;
+}

--- a/contracts/tokens/IFxMintableERC721.sol
+++ b/contracts/tokens/IFxMintableERC721.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {IERC721} from "../lib/IERC721.sol";
+
+interface IFxMintableERC721 is IERC721 {
+    function fxManager() external returns (address);
+
+    function connectedToken() external returns (address);
+
+    function initialize(
+        address fxManager,
+        address connectedToken,
+        string calldata name,
+        string calldata symbol,
+        address minter
+    ) external;
+
+    function mintToken(
+        address user,
+        uint256 tokenId,
+        bytes calldata _data
+    ) external;
+
+    function burn(uint256 tokenId) external;
+}


### PR DESCRIPTION
This PR adds example tunnel implementations for mintable ERC721 and mintable ERC1155. 

Note: Tests were also written [here](https://github.com/DhairyaSethi/fx-portal-contracts/tree/mintable/test/tunnel) which base on test setup at [hardhat_unittest](https://github.com/fx-portal/contracts/tree/feature/hardhat_unittest) branch; this branch (and hence hardhat test setup) isn't merged on master yet.