### PR TITLE
fix: broken bridge docs links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ While Fx-portal focuses on permissionless-ness and flexibility, a developer migh
 
 **Can I build my bridge?**
 
-Yes. You can check docs here: https://docs.matic.network/docs/develop/l1-l2-communication/ethereum-to-matic
-https://docs.matic.network/docs/develop/l1-l2-communication/matic-to-ethereum
+Yes. You can check docs here: https://wiki.polygon.technology/docs/develop/l1-l2-communication/ethereum-to-matic/
+https://wiki.polygon.technology/docs/develop/l1-l2-communication/matic-to-ethereum/
 
 ### What are FxChild and FxRoot?
 


### PR DESCRIPTION
This PR aims to fix the broken links to the bridge docs in the readme file.