### PR TITLE
added  SPDX license identifier to ExitPayloadReader and Rlp reader

### DIFF
--- a/contracts/lib/ExitPayloadReader.sol
+++ b/contracts/lib/ExitPayloadReader.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0
+// SPDX-License-Identifier: MIT
 
 pragma solidity ^0.8.0;
 

--- a/contracts/lib/ExitPayloadReader.sol
+++ b/contracts/lib/ExitPayloadReader.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0
+
 pragma solidity ^0.8.0;
 
 import {RLPReader} from "./RLPReader.sol";

--- a/contracts/lib/RLPReader.sol
+++ b/contracts/lib/RLPReader.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 
 /*
  * @author Hamdi Allam hamdi.allam97@gmail.com

--- a/contracts/lib/RLPReader.sol
+++ b/contracts/lib/RLPReader.sol
@@ -1,7 +1,10 @@
+// SPDX-License-Identifier: GPL-3.0
+
 /*
  * @author Hamdi Allam hamdi.allam97@gmail.com
  * Please reach out with any questions or concerns
  */
+
 pragma solidity ^0.8.0;
 
 library RLPReader {

--- a/contracts/lib/RLPReader.sol
+++ b/contracts/lib/RLPReader.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0
+// SPDX-License-Identifier: MIT
 
 /*
  * @author Hamdi Allam hamdi.allam97@gmail.com


### PR DESCRIPTION
This code resolves the issue #37 by adding the MIT SPDX license identifier to the Exitpayload Reader and Apache 2.0  to RLP reader contract.
